### PR TITLE
Fix bracken sorting

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -258,7 +258,7 @@ vcf
 Compares SNPs identified in vcf file to lists in reference table */
 
 process AssignClusterCSS{
-	errorStrategy 'finish'
+	errorStrategy 'ignore'
     tag "$pair_id"
 	
 

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -18,9 +18,9 @@ kraken2 --threads 2 --quick $lowmem --db $kraken2db --output - --report ${pair_i
 set +e
 
 bracken -d $kraken2db -r 150 -l S -t 10 -i ${pair_id}_"$outcome"_kraken2.tab -o ${pair_id}_"$outcome"_bracken.out
-sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'t' -k7,7 -nr - | head -20 > ${pair_id}_"$outcome"_brackensort.tab
+sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'\t' -k7,7 -nr - | head -20 > ${pair_id}_"$outcome"_brackensort.tab
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
-( sed -u 1q; sort -t $'t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
+( sed -u 1q; sort -t $'\t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
 BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
  awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
 echo "Sample,ID,TotalReads,Abundance" > ${pair_id}_bovis.csv

--- a/bin/varCall.bash
+++ b/bin/varCall.bash
@@ -5,5 +5,5 @@ ref=$2
 
 samtools index ${pair_id}.mapped.sorted.bam
 bcftools mpileup -Q 10 -Ou -f $ref "${pair_id}.mapped.sorted.bam" |
-bcftools call --ploidy 1 -cf GQ - -Ou |
+bcftools call -mf GQ - -Ou |
 bcftools norm -f $ref - -Oz -o "${pair_id}.norm.vcf.gz"


### PR DESCRIPTION
Just a minor bug fix to correct the sorting of the bracken output files.  Looks like I was overzealous when removing escapes in an earlier commit!