### PR TITLE
Clean deduplicate

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -86,14 +86,14 @@ process Deduplicate {
 	maxForks 2
 
 	input:
-	set pair_id, file("${pair_id}_*_R1_*.fastq.gz"), file("${pair_id}_*_R2_*.fastq.gz") from read_pairs
+	tuple pair_id, pair_1, pair_2 from read_pairs
 
 	output:
-	set pair_id, file("${pair_id}_uniq_R1.fastq"), file("${pair_id}_uniq_R2.fastq") into dedup_read_pairs
-	set pair_id, file("${pair_id}_uniq_R1.fastq"), file("${pair_id}_uniq_R2.fastq") into uniq_reads
+	tuple pair_id, file("deduplicated_1.fastq"), file("deduplicated_2.fastq") into dedup_read_pairs
+	tuple pair_id, file("deduplicated_1.fastq"), file("deduplicated_2.fastq") into uniq_reads
 
 	"""
-	deduplicate.bash ${pair_id}
+	deduplicate.bash $pair_1 $pair_2 deduplicated_1.fastq deduplicated_2.fastq
 	"""
 }	
 

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -89,11 +89,10 @@ process Deduplicate {
 	tuple pair_id, pair_1, pair_2 from read_pairs
 
 	output:
-	tuple pair_id, file("deduplicated_1.fastq"), file("deduplicated_2.fastq") into dedup_read_pairs
-	tuple pair_id, file("deduplicated_1.fastq"), file("deduplicated_2.fastq") into uniq_reads
+	tuple pair_id, file("dedup_1.fastq"), file("dedup_2.fastq") into dedup_read_pairs, uniq_reads
 
 	"""
-	deduplicate.bash $pair_1 $pair_2 deduplicated_1.fastq deduplicated_2.fastq
+	deduplicate.bash $pair_1 $pair_2 dedup_1.fastq dedup_2.fastq
 	"""
 }	
 

--- a/bin/deduplicate.bash
+++ b/bin/deduplicate.bash
@@ -3,7 +3,7 @@
 # Deduplicate
 #================================================================
 #% SYNOPSIS
-#+    bov-tb reads_dir results_dir
+#+    Deduplicate.bash pair_1 pair_2 deduplicated_1 deduplicated_2
 #%
 #% DESCRIPTION
 #%    Removes potential duplicate data (sequencing and optical replcaites from the raw data set) from a pair of .fastq.gz files using FastUniq

--- a/bin/deduplicate.bash
+++ b/bin/deduplicate.bash
@@ -1,15 +1,36 @@
 #!/bin/bash
+#================================================================
+# Deduplicate
+#================================================================
+#% SYNOPSIS
+#+    bov-tb reads_dir results_dir
+#%
+#% DESCRIPTION
+#%    Removes potential duplicate data (sequencing and optical replcaites from the raw data set) from a pair of .fastq.gz files using FastUniq
+#%
+#% INPUTS
+#%    pair_1          input path to first fastq.gz read file
+#%    pair_2          input path to second fastq.gz read file
+#%    deduplicated_1  output path to first deduplicated file
+#%    deduplicated_2  output path to second deduplicated file
 
-# This process removes potential duplicate data (sequencing and optical replcaites from the raw data set
-
-
-pair_id=$1
+# Inputs
+pair_1=$1
+pair_2=$2
+deduplicated_1=$3
+deduplicated_2=$4
 
 nl=$'\n'
 
-gunzip -c ${pair_id}_*_R1_*.fastq.gz > ${pair_id}_R1.fastq 
-gunzip -c ${pair_id}_*_R2_*.fastq.gz > ${pair_id}_R2.fastq
-echo "${pair_id}_R1.fastq${nl}${pair_id}_R2.fastq" > fqin.lst
-fastuniq -i fqin.lst -o ${pair_id}_uniq_R1.fastq -p ${pair_id}_uniq_R2.fastq
-rm ${pair_id}_R1.fastq
-rm ${pair_id}_R2.fastq
+# Unzip
+gunzip -c $pair_1 > R1.fastq 
+gunzip -c $pair_2 > R2.fastq
+
+# Input List
+echo "R1.fastq${nl}R2.fastq" > fqin.lst
+
+# FastUniq
+fastuniq -i fqin.lst -o $deduplicated_1 -p $deduplicated_2
+
+# Cleanup
+rm R1.fastq R2.fastq fqin.lst

--- a/tests/unit_tests/btb_tests.py
+++ b/tests/unit_tests/btb_tests.py
@@ -5,7 +5,8 @@ import os
 
 class BtbTests(unittest.TestCase):
     """
-        TODO: break this out into individual classes for each nextflow process.
+        Base class for btb-seq unit tests
+        Contains tools that make writing unit tests for nextflow processes easier
     """
     def setUp(self):
         """

--- a/tests/unit_tests/btb_tests.py
+++ b/tests/unit_tests/btb_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import tempfile
+import os
 
 class BtbTests(unittest.TestCase):
     """
@@ -32,6 +33,13 @@ class BtbTests(unittest.TestCase):
 
         actual_exit_code = subprocess.run(['bash', '-e'] + cmd).returncode
         self.assertEqual(expected_exit_code, actual_exit_code)
+
+    def assertFileExists(self, filepath):
+        """
+            Raises an exception if the file does not exist
+        """
+        if not os.path.exists(filepath):
+            raise Exception(f"File does not exist: {filepath}")
 
     def sam_to_bam(self, sam_filepath, bam_filepath):
         # Convert to SAM to BAM

--- a/tests/unit_tests/deduplicate_tests.py
+++ b/tests/unit_tests/deduplicate_tests.py
@@ -8,6 +8,7 @@ class DeduplicateTests(BtbTests):
     def test_deduplicate(self):
         """
             This introductory unit test asserts the deduplicate process completes on tinyreads without errors.
+            And produces two fastq files
         """
 
         # Copy test data
@@ -18,6 +19,8 @@ class DeduplicateTests(BtbTests):
         self.assertBashScript(0, ['./bin/deduplicate.bash', reads[0], reads[1], outputs[0], outputs[1]])
         self.assertFileExists(outputs[0])
         self.assertFileExists(outputs[1])
+
+        # TODO: Assert that duplicates are actually removed
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/deduplicate_tests.py
+++ b/tests/unit_tests/deduplicate_tests.py
@@ -1,6 +1,8 @@
-from btb_tests import BtbTests
+import unittest
 import glob
 import shutil
+
+from btb_tests import BtbTests
 
 class DeduplicateTests(BtbTests):
     def test_deduplicate(self):
@@ -9,10 +11,11 @@ class DeduplicateTests(BtbTests):
         """
 
         # Copy test data
-        pair_id = self.temp_dirname + 'tinyreads'
-
-        for file in glob.glob(r'./tests/data/tinyreads/*'):
-            shutil.copy(file, self.temp_dirname)
+        reads = glob.glob(r'./tests/data/tinyreads/*') 
+        outputs = [self.temp_dirname+'1.txt', self.temp_dirname+'2.txt']
 
         # Test the script
-        self.assertBashScript(0, ['./bin/deduplicate.bash', pair_id])
+        self.assertBashScript(0, ['./bin/deduplicate.bash', reads[0], reads[1], outputs[0], outputs[1]])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/deduplicate_tests.py
+++ b/tests/unit_tests/deduplicate_tests.py
@@ -16,6 +16,9 @@ class DeduplicateTests(BtbTests):
 
         # Test the script
         self.assertBashScript(0, ['./bin/deduplicate.bash', reads[0], reads[1], outputs[0], outputs[1]])
+        self.assertFileExists(outputs[0])
+        self.assertFileExists(outputs[1])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR cleans up Nextflow code for the dudplicate process. Now `deduplicate.bash` can input/output with any filenames. This is a more flexible approach that makes testing and ad-hoc data analysis tasks easier. If you like this pattern, I would like to tidy up the other nextflow processes in similar fashion:
- Modified command line args for `deduplicate.bash`
- Cleaner `deduplicate.bash` code
- Tidier deduplicate nextflow code (`set` is now deprecated for tuple, and also made things less verbose)
- Improved deduplicate unit tests that assert output fastq files are produced