### PR TITLE
Clean map2ref and VarCall

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -61,6 +61,8 @@ discrimPos = file(params.discrimPos)
 pypath = file(params.pypath)
 kraken2db = file(params.kraken2db)
 
+publishDir = "$params.outdir/Results_${params.DataDir}_${params.today}/"
+
 /*	Collect pairs of fastq files and infer sample names
 Define the input raw sequening data files */
 Channel
@@ -121,20 +123,18 @@ process Map2Ref {
 	errorStrategy 'finish'
     tag "$pair_id"
 
-	publishDir "$params.outdir/Results_${params.DataDir}_${params.today}/bam", mode: 'copy', pattern: '*.sorted.bam'
+	publishDir "$publishDir/bam", mode: 'copy', pattern: '*.bam'
 
 	maxForks 2
 
 	input:
-	set pair_id, file("${pair_id}_trim_R1.fastq"), file("${pair_id}_trim_R2.fastq") from trim_read_pairs
+	tuple pair_id, file("read_1.fastq"), file("read_2.fastq") from trim_read_pairs
 
 	output:
-	set pair_id, file("${pair_id}.mapped.sorted.bam") into mapped_bam
-	set pair_id, file("${pair_id}.mapped.sorted.bam") into bam4stats
-	set pair_id, file("${pair_id}.mapped.sorted.bam") into bam4mask
+	tuple pair_id, file("mapped.bam") into mapped_bam, bam4stats, bam4mask
 
 	"""
-	map2Ref.bash ${pair_id} $ref
+	map2Ref.bash $ref read_1.fastq read_2.fastq mapped.bam
 	"""
 }
 

--- a/bin/map2Ref.bash
+++ b/bin/map2Ref.bash
@@ -21,6 +21,6 @@ read_2=$3
 mapped=$4
 
 # Map to reference
-bwa mem -M -t2 $ref  $read_1 $read_2 |
+bwa mem -M -t2 $ref $read_1 $read_2 |
 samtools view -@2 -ShuF 2308 - |
 samtools sort -@2 - -o $mapped

--- a/bin/map2Ref.bash
+++ b/bin/map2Ref.bash
@@ -1,9 +1,26 @@
-# map to reference sequence
-# Aligns the individiual sequence reads to the reference genome 
+#!/bin/bash
+#================================================================
+# map2Ref
+#================================================================
+#% SYNOPSIS
+#+    map2Ref.bash ref read_1 read_2 mapped
+#%
+#% DESCRIPTION
+#%    Map to reference sequence. Aligns the individiual sequence reads to the reference genome
+#%
+#% INPUTS
+#%    ref             path to input reference fasta file
+#%    read_1          path to first input fastq read file
+#%    read_2          path to second input fastq read file
+#%    mapped          path to output mapped bam file
 
-pair_id=$1
-ref=$2
+# Args
+ref=$1
+read_1=$2
+read_2=$3
+mapped=$4
 
-bwa mem -M -t2 $ref  ${pair_id}_trim_R1.fastq ${pair_id}_trim_R2.fastq |
+# Map to reference
+bwa mem -M -t2 $ref  $read_1 $read_2 |
 samtools view -@2 -ShuF 2308 - |
-samtools sort -@2 - -o ${pair_id}.mapped.sorted.bam
+samtools sort -@2 - -o $mapped

--- a/bin/varCall.bash
+++ b/bin/varCall.bash
@@ -1,9 +1,26 @@
+#!/bin/bash
+#================================================================
+# varCall
+#================================================================
+#% SYNOPSIS
+#+    varCall.bash ref read_1 read_2 mapped
+#%
+#% DESCRIPTION
+#%    Determines where the sample differs from the reference genome
+#%
+#% INPUTS
+#%    ref             path to input reference fasta file
+#%    bam             path to first input fastq read file
+#%    vcf             path to output vcf.gz file
+
+
 # Determines where the sample differs from the reference genome
 
-pair_id=$1
-ref=$2
+ref=$1
+bam=$2
+vcf=$3
 
-samtools index ${pair_id}.mapped.sorted.bam
-bcftools mpileup -Q 10 -Ou -f $ref "${pair_id}.mapped.sorted.bam" |
+samtools index $bam
+bcftools mpileup -Q 10 -Ou -f $ref "$bam" |
 bcftools call -mf GQ - -Ou |
-bcftools norm -f $ref - -Oz -o "${pair_id}.norm.vcf.gz"
+bcftools norm -f $ref - -Oz -o "$vcf"

--- a/tests/unit_tests/btb_tests.py
+++ b/tests/unit_tests/btb_tests.py
@@ -72,13 +72,17 @@ class BtbTests(unittest.TestCase):
         # Unzip
         if unzip:
             for read in reads:
-                proc = subprocess.run(['gunzip', read])
-                self.assertFalse(proc.returncode)
+                self.unzip(read)
 
             reads = [read[:-3] for read in reads]
 
         # Return path to files
         return reads
+
+    def unzip(self, path):
+        """ Unzip a .gz file inplace """
+        proc = subprocess.run(['gunzip', path])
+        self.assertFalse(proc.returncode)
 
     def write_fastq(self, filepath, seq_records):
         """

--- a/tests/unit_tests/btb_tests.py
+++ b/tests/unit_tests/btb_tests.py
@@ -54,6 +54,11 @@ class BtbTests(unittest.TestCase):
         # Convert to SAM to BAM
         with open(bam_filepath, 'w') as f:
             subprocess.call(['samtools', 'view', '-S', '-b', sam_filepath], stdout=f)
+    
+    def bam_to_sam(self, bam_filepath, sam_filepath):
+        # Convert to BAM to SAM
+        proc = subprocess.run(['samtools', 'view', '-h', '-o', sam_filepath, bam_filepath])
+        self.assertEquals(0, proc.returncode)
 
     def copy_tinyreads(self, unzip=False):
         """

--- a/tests/unit_tests/map2Ref_tests.py
+++ b/tests/unit_tests/map2Ref_tests.py
@@ -4,10 +4,9 @@ from btb_tests import BtbTests
 class Map2RefTests(BtbTests):
     ref_path = './references/Mycbovis-2122-97_LT708304.fas'
 
-    def test_trim(self):
+    def test_map2ref(self):
         """
-            This introductory unit test asserts trim.bash completes on tinyreads without errors.
-            And produces two fastq files
+            Asserts map2ref.bash completes on tinyreads without errors and produces a named bam file
         """        
 
         # Copy test data

--- a/tests/unit_tests/map2Ref_tests.py
+++ b/tests/unit_tests/map2Ref_tests.py
@@ -1,0 +1,27 @@
+import unittest
+from btb_tests import BtbTests
+
+class Map2RefTests(BtbTests):
+    ref_path = './references/Mycbovis-2122-97_LT708304.fas'
+
+    def test_trim(self):
+        """
+            This introductory unit test asserts trim.bash completes on tinyreads without errors.
+            And produces two fastq files
+        """        
+
+        # Copy test data
+        reads = self.copy_tinyreads(unzip=True)
+
+        # Output Filenames
+        output = self.temp_dirname + 'mapped.bam'
+
+        # Pass case
+        self.assertBashScript(0, ['./bin/map2Ref.bash', self.ref_path, reads[0], reads[1], output])
+        self.assertFileExists(output)
+
+        # Covert to SAM for visual checking
+        self.bam_to_sam(output, self.temp_dirname+'mapped.sam')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/unit_tests.py
+++ b/tests/unit_tests/unit_tests.py
@@ -13,6 +13,7 @@ from trim_tests import TrimTests
 from mask_tests import MaskTests
 from read_stats_tests import ReadStatsTests
 from map2Ref_tests import Map2RefTests
+from varCall_tests import VarCallTests
 
 def main():
     # Test List
@@ -21,7 +22,8 @@ def main():
         TrimTests,
         MaskTests,
         ReadStatsTests,
-        Map2RefTests
+        Map2RefTests,
+        VarCallTests
     ]
 
     # Load 'em up

--- a/tests/unit_tests/unit_tests.py
+++ b/tests/unit_tests/unit_tests.py
@@ -12,6 +12,7 @@ from deduplicate_tests import DeduplicateTests
 from trim_tests import TrimTests
 from mask_tests import MaskTests
 from read_stats_tests import ReadStatsTests
+from map2Ref_tests import Map2RefTests
 
 def main():
     # Test List
@@ -19,7 +20,8 @@ def main():
         DeduplicateTests,
         TrimTests,
         MaskTests,
-        ReadStatsTests
+        ReadStatsTests,
+        Map2RefTests
     ]
 
     # Load 'em up

--- a/tests/unit_tests/varCall_tests.py
+++ b/tests/unit_tests/varCall_tests.py
@@ -2,7 +2,7 @@ import shutil
 import unittest
 from btb_tests import BtbTests
 
-class Map2RefTests(BtbTests):
+class VarCallTests(BtbTests):
     ref_path = './references/Mycbovis-2122-97_LT708304.fas'
 
     def test_varCall(self):

--- a/tests/unit_tests/varCall_tests.py
+++ b/tests/unit_tests/varCall_tests.py
@@ -1,0 +1,30 @@
+import shutil
+import unittest
+from btb_tests import BtbTests
+
+class Map2RefTests(BtbTests):
+    ref_path = './references/Mycbovis-2122-97_LT708304.fas'
+
+    def test_varCall(self):
+        """
+            Asserts varCall.bash completes on tinymatch.sam without errors and produces a vcf file
+        """
+        sam_path = self.temp_dirname + '/tinymatch.sam'
+        bam_path = self.temp_dirname + '/tinymatch.bam'
+        output = self.temp_dirname + 'variants.vcf.gz'
+
+        # Copy test data
+        shutil.copy2('./tests/data/tinymatch.sam', sam_path)
+
+        # Convert to BAM
+        self.sam_to_bam(sam_path, bam_path)
+
+        # Pass case
+        self.assertBashScript(0, ['./bin/varCall.bash', self.ref_path, bam_path, output])
+        self.assertFileExists(output)
+
+        # Unzip
+        self.unzip(output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Cleaning two processes on this PR as they are quite small:#
- Cleaner `map2Ref` and `varCall` nextflow processes
- DRYing up `publishDir` path
- basic unit tests for map2ref and varCall bash scripts