### PR TITLE
Refine combination of output tables

### DIFF
--- a/bin/combineCsv.py
+++ b/bin/combineCsv.py
@@ -37,7 +37,7 @@ def combine(assigned_csv, bovis_csv, seq_run, read_threshold, abundance_threshol
     qbovis_df['Abundance'].fillna('0', inplace = True)
     qbovis_df['ID'].fillna('Negative', inplace = True)
 
-    #Merge dataframes and fill ID with M bovis if Pass, then any remaining blank cells with 'NA'
+    #Merge dataframes fill with appropriate Mycobacterium ID (Other, microti, bovis), then any remaining blank cells with 'NA'
     finalout_df = pd.merge(assignedround_df, qbovis_df, on = 'Sample', how = 'outer')
     finalout_df.loc[(finalout_df['group'] == 'nonbTB' ) | (finalout_df['group'] == 'MicPin' ) | (finalout_df['group'] == 'Pinnipedii' ), 'ID' ] = 'Other Mycobacterium'
     finalout_df.loc[(finalout_df['group'] == 'Microti' ), 'ID' ] = 'Mycobacterium microti'

--- a/bin/combineCsv.py
+++ b/bin/combineCsv.py
@@ -39,6 +39,8 @@ def combine(assigned_csv, bovis_csv, seq_run, read_threshold, abundance_threshol
 
     #Merge dataframes and fill ID with M bovis if Pass, then any remaining blank cells with 'NA'
     finalout_df = pd.merge(assignedround_df, qbovis_df, on = 'Sample', how = 'outer')
+    finalout_df.loc[(finalout_df['group'] == 'nonbTB' ) | (finalout_df['group'] == 'MicPin' ) | (finalout_df['group'] == 'Pinnipedii' ), 'ID' ] = 'Other Mycobacterium'
+    finalout_df.loc[(finalout_df['group'] == 'Microti' ), 'ID' ] = 'Mycobacterium microti'
     finalout_df['ID'].fillna('Mycobacterium bovis', inplace = True)
     finalout_df.fillna('NA', inplace = True)
     finalout_df.set_index('Sample', inplace = True)

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -21,7 +21,7 @@ bracken -d $kraken2db -r 150 -l S -t 10 -i ${pair_id}_"$outcome"_kraken2.tab -o 
 sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'\t' -k7,7 -nr - | head -20 > ${pair_id}_"$outcome"_brackensort.tab
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
 ( sed -u 1q; sort -t $'\t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
-# Need bovis to be the top tuberculosis (or Mycobacterium??) variant for better confidence in confiming ID
+# Need bovis to be the top Mycobacterium variant for better confidence in confiming ID
 MycoPos=$(grep -m 1 'Mycobacterium' ${pair_id}_"$outcome"-S1_brackensort.tab)
 BovPos=$(echo $MycoPos | grep 'variant bovis' | awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
 # Original code:

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -21,8 +21,13 @@ bracken -d $kraken2db -r 150 -l S -t 10 -i ${pair_id}_"$outcome"_kraken2.tab -o 
 sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'\t' -k7,7 -nr - | head -20 > ${pair_id}_"$outcome"_brackensort.tab
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
 ( sed -u 1q; sort -t $'\t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
-BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
- awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
+# Need bovis to be the top tuberculosis (or Mycobacterium??) variant for better confidence in confiming ID
+MycoPos=$(grep -m 1 'Mycobacterium' ${pair_id}_"$outcome"-S1_brackensort.tab)
+BovPos=$(echo $MycoPos | grep 'variant bovis' | awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
+# Original code:
+#BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
+# awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
+
 echo "Sample,ID,TotalReads,Abundance" > ${pair_id}_bovis.csv
 echo "${pair_id},"$BovPos"" >> ${pair_id}_bovis.csv
 

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -21,12 +21,10 @@ bracken -d $kraken2db -r 150 -l S -t 10 -i ${pair_id}_"$outcome"_kraken2.tab -o 
 sed 1d ${pair_id}_"$outcome"_bracken.out | sort -t $'\t' -k7,7 -nr - | head -20 > ${pair_id}_"$outcome"_brackensort.tab
 bracken -d $kraken2db -r150 -l S1 -i ${pair_id}_"${outcome}"_kraken2.tab -o ${pair_id}_"$outcome"-S1_bracken.out
 ( sed -u 1q; sort -t $'\t' -k7,7 -nr ) < ${pair_id}_"$outcome"-S1_bracken.out > ${pair_id}_"$outcome"-S1_brackensort.tab
-# Need bovis to be the top Mycobacterium variant for better confidence in confiming ID
+# Need bovis to be the top Mycobacterium variant for better confidence in confiming M bovis ID - reduce false positives
 MycoPos=$(grep -m 1 'Mycobacterium' ${pair_id}_"$outcome"-S1_brackensort.tab)
-BovPos=$(echo $MycoPos | grep 'variant bovis' | awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
-# Original code:
-#BovPos=$(grep 'variant bovis' ${pair_id}_"$outcome"-S1_brackensort.tab |
-# awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
+BovPos=$(echo $MycoPos | grep 'variant bovis' |
+ awk '{printf $1" "$2" "$3" "$4","$9"," "%.3f", ($10*100)}' || true)
 
 echo "Sample,ID,TotalReads,Abundance" > ${pair_id}_bovis.csv
 echo "${pair_id},"$BovPos"" >> ${pair_id}_bovis.csv


### PR DESCRIPTION
This pull request is to improve the accuracy of parsing the bracken output, and to ensure that non-_M.bovis_ samples are identified as such.  Additional filters have been added to identify _M.microti_ and 'Other Mycobacterium'.  The new output is matched to corresponding filters in LIMS.