### PR TITLE
Adjust validation stats to subtract masked positions from SNPs

### DIFF
--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -8,8 +8,8 @@ Calculate performance stats from simulated data
 
 # TODO: Should this be replaced with vcftools?
 def masked_positions(mask_filepath='../references/Mycbovis-2122-97_LT708304.fas.rpt.regions'):
-    mask = pd.read_csv(mask_filepath, 
-        delimiter='\t', 
+    mask = pd.read_csv(mask_filepath,
+        delimiter='\t',
         skiprows=[0,1],
         header=None,
         names=["CHROM", "START", "END", "RPT"]

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -6,7 +6,6 @@ from Bio import SeqIO
 Calculate performance stats from simulated data
 """
 
-# TODO: Should this be replaced with vcftools?
 def masked_positions(mask_filepath='../references/Mycbovis-2122-97_LT708304.fas.rpt.regions'):
     mask = pd.read_csv(mask_filepath,
         delimiter='\t',
@@ -23,7 +22,7 @@ def masked_positions(mask_filepath='../references/Mycbovis-2122-97_LT708304.fas.
 
     return masked_pos
 
-def analyse(simulated_snps, pipeline_snps, adjust = False):
+def analyse(simulated_snps, pipeline_snps):
     """ Compare simulated SNPs data from simuG against btb-seq's snpTable.tab
         If adjust == True: applies the mask to simulated SNPs and pipeline SNPs
         Returns a dictionary of performance stats
@@ -36,13 +35,10 @@ def analyse(simulated_snps, pipeline_snps, adjust = False):
     # Extract SNP positions
     simulated_pos = set(simulated['ref_start'].values)
     pipeline_pos = set(pipeline['POS'].values)
+    masked_pos = set(masked_positions())
 
-    # TODO: Do we need to remove masked positions? 
-    # TODO: Should our filtering step apply the mask? TBD with Ele/Richard
-    if adjust:
-        masked_pos = set(masked_positions())
-        simulated_pos -= masked_pos
-        pipeline_pos -= masked_pos
+    simulated_pos -= masked_pos
+    pipeline_pos -= masked_pos
 
     # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
     tp = len(simulated_pos.intersection(pipeline_pos))

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -37,17 +37,26 @@ def analyse(simulated_snps, pipeline_snps):
     pipeline_pos = set(pipeline['POS'].values)
     masked_pos = set(masked_positions())
 
-    simulated_pos -= masked_pos
-    pipeline_pos -= masked_pos
+    simulated_pos_adjusted = simulated_pos - masked_pos
+    pipeline_pos_adjusted = pipeline_pos - masked_pos
 
     # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
-    tp = len(simulated_pos.intersection(pipeline_pos))
+    tp = len(simulated_pos.intersection(pipeline_pos_adjusted))
 
     # FP (the pipeline calls a variant that is not in the simulated genome),
-    fp = len(pipeline_pos - simulated_pos)
+    fp = len(pipeline_pos_adjusted - simulated_pos_adjusted)
 
     # FN SNP calls (the variant is in the simulated genome but the pipeline does not call it).
-    fn =  len(simulated_pos - pipeline_pos)
+    fn =  len(simulated_pos_adjusted - pipeline_pos_adjusted)
+
+    # TPs excluded 
+    masked_tp = len(masked_pos.intersection(simulated_pos.intersection(pipeline_pos)))
+
+    # FPs excluded
+    masked_fp = len(masked_pos.intersection(simulated_pos - pipeline_pos))
+
+    # FNs excluded
+    masked_fn = len(masked_pos.intersection(simulated_pos - pipeline_pos))
 
     # Compute Performance Stats
     # precision (positive predictive value) of each pipeline as TP/(TP + FP), 
@@ -63,9 +72,12 @@ def analyse(simulated_snps, pipeline_snps):
     total_errors = fp + fn
 
     return {
-        "tp": tp,
-        "fp": fp,
-        "fn": fn,
+        "TP": tp,
+        "FP": fp,
+        "FN": fn,
+        "masked TPs": masked_tp,
+        "masked FPs": masked_fp,
+        "masked FNs": masked_fn,
         "precision": precision,
         "sensitivity": sensitivity,
         "miss_rate": miss_rate,

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -6,8 +6,27 @@ from Bio import SeqIO
 Calculate performance stats from simulated data
 """
 
-def analyse(simulated_snps, pipeline_snps):
+# TODO: Should this be replaced with vcftools?
+def masked_positions(mask_filepath='../references/Mycbovis-2122-97_LT708304.fas.rpt.regions'):
+    mask = pd.read_csv(mask_filepath, 
+        delimiter='\t', 
+        skiprows=[0,1],
+        header=None,
+        names=["CHROM", "START", "END", "RPT"]
+    )
+
+    # TODO: This is off by one compared to the Emergency Port validation doc
+    #    why is that?
+    masked_pos = []
+    for i, row in mask.iterrows():
+        masked_pos.extend(list(range(row['START'], row['END']+1)))
+        #print('masked_pos', masked_pos[-1])
+
+    return masked_pos
+
+def analyse_basic(simulated_snps, pipeline_snps):
     """ Compare simulated SNPs data from simuG against btb-seq's snpTable.tab
+        No masking on simulated SNPs
         Returns a dictionary of performance stats
     """
 
@@ -18,7 +37,7 @@ def analyse(simulated_snps, pipeline_snps):
     # Extract SNP positions
     simulated_pos = set(simulated['ref_start'].values)
     pipeline_pos = set(pipeline['POS'].values)
-    
+
     # TODO: Do we need to remove masked positions? 
     # TODO: Should our filtering step apply the mask? TBD with Ele/Richard
     # simulated_pos -= masked_pos
@@ -56,24 +75,57 @@ def analyse(simulated_snps, pipeline_snps):
         "total_errors": total_errors
     }
 
-# TODO: Should this be replaced with vcftools?
-def masked_positions(mask_filepath='./references/Mycbovis-2122-97_LT708304.fas.rpt.regions'):
-    mask = pd.read_csv(mask_filepath, 
-        delimiter='\t', 
-        skiprows=2,
-        header=None,
-        names=["name", "start", "end", "mask"]
-    )
+def analyse_mask_adjust(simulated_snps, pipeline_snps):
+    """ Compare simulated SNPs data from simuG against btb-seq's snpTable.tab
+        Applies the mask to simulated SNPs
+        Returns a dictionary of performance stats
+    """
 
-    # TODO: This is off by one compared to the Emergency Port validation doc
-    #    why is that?
-    masked_pos = []
-    for i, row in mask.iterrows():
-        masked_pos.extend(range(row['start'], row['end']+1))
-        print('masked_pos', masked_pos[-1])
-        break
+    # Load
+    simulated = pd.read_csv(simulated_snps, delimiter='\t')
+    pipeline = pd.read_csv(pipeline_snps, delimiter='\t')
 
-    return masked_pos
+    # Extract SNP positions
+    simulated_pos = set(simulated['ref_start'].values)
+    pipeline_pos = set(pipeline['POS'].values)
+    masked_pos = set(masked_positions())
+
+    # TODO: Do we need to remove masked positions? 
+    # TODO: Should our filtering step apply the mask? TBD with Ele/Richard
+    simulated_pos -= masked_pos
+    pipeline_pos -= masked_pos
+
+    # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
+    tp = len(simulated_pos.intersection(pipeline_pos))
+
+    # FP (the pipeline calls a variant that is not in the simulated genome),
+    fp = len(pipeline_pos - simulated_pos)
+
+    # FN SNP calls (the variant is in the simulated genome but the pipeline does not call it).
+    fn =  len(simulated_pos - pipeline_pos)
+
+    # Compute Performance Stats
+    # precision (positive predictive value) of each pipeline as TP/(TP + FP), 
+    precision = tp / (tp + fp)
+
+    # recall (sensitivity) as TP/(TP + FN)
+    sensitivity = tp / (tp + fn)
+
+    # miss rate as FN/(TP + FN)
+    miss_rate = fn / (tp + fn)
+
+    #  total number of errors (FP + FN) per million sequenced bases
+    total_errors = fp + fn
+
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": precision,
+        "sensitivity": sensitivity,
+        "miss_rate": miss_rate,
+        "total_errors": total_errors
+    }
 
 #TODO: This may not be required if we can get away with using bcftools/vcftools
 #      for comparisons. Leaving this here for convenience in case those tools aren't suitable 

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -20,13 +20,12 @@ def masked_positions(mask_filepath='../references/Mycbovis-2122-97_LT708304.fas.
     masked_pos = []
     for i, row in mask.iterrows():
         masked_pos.extend(list(range(row['START'], row['END']+1)))
-        #print('masked_pos', masked_pos[-1])
 
     return masked_pos
 
-def analyse_basic(simulated_snps, pipeline_snps):
+def analyse(simulated_snps, pipeline_snps, adjust = False):
     """ Compare simulated SNPs data from simuG against btb-seq's snpTable.tab
-        No masking on simulated SNPs
+        If adjust == True: applies the mask to simulated SNPs and pipeline SNPs
         Returns a dictionary of performance stats
     """
 
@@ -40,60 +39,10 @@ def analyse_basic(simulated_snps, pipeline_snps):
 
     # TODO: Do we need to remove masked positions? 
     # TODO: Should our filtering step apply the mask? TBD with Ele/Richard
-    # simulated_pos -= masked_pos
-    # pipeline_pos -= masked_pos
-
-    # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
-    tp = len(simulated_pos.intersection(pipeline_pos))
-
-    # FP (the pipeline calls a variant that is not in the simulated genome),
-    fp = len(pipeline_pos - simulated_pos)
-
-    # FN SNP calls (the variant is in the simulated genome but the pipeline does not call it).
-    fn =  len(simulated_pos - pipeline_pos)
-
-    # Compute Performance Stats
-    # precision (positive predictive value) of each pipeline as TP/(TP + FP), 
-    precision = tp / (tp + fp)
-
-    # recall (sensitivity) as TP/(TP + FN)
-    sensitivity = tp / (tp + fn)
-
-    # miss rate as FN/(TP + FN)
-    miss_rate = fn / (tp + fn)
-
-    #  total number of errors (FP + FN) per million sequenced bases
-    total_errors = fp + fn
-
-    return {
-        "tp": tp,
-        "fp": fp,
-        "fn": fn,
-        "precision": precision,
-        "sensitivity": sensitivity,
-        "miss_rate": miss_rate,
-        "total_errors": total_errors
-    }
-
-def analyse_mask_adjust(simulated_snps, pipeline_snps):
-    """ Compare simulated SNPs data from simuG against btb-seq's snpTable.tab
-        Applies the mask to simulated SNPs
-        Returns a dictionary of performance stats
-    """
-
-    # Load
-    simulated = pd.read_csv(simulated_snps, delimiter='\t')
-    pipeline = pd.read_csv(pipeline_snps, delimiter='\t')
-
-    # Extract SNP positions
-    simulated_pos = set(simulated['ref_start'].values)
-    pipeline_pos = set(pipeline['POS'].values)
-    masked_pos = set(masked_positions())
-
-    # TODO: Do we need to remove masked positions? 
-    # TODO: Should our filtering step apply the mask? TBD with Ele/Richard
-    simulated_pos -= masked_pos
-    pipeline_pos -= masked_pos
+    if adjust:
+        masked_pos = set(masked_positions())
+        simulated_pos -= masked_pos
+        pipeline_pos -= masked_pos
 
     # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
     tp = len(simulated_pos.intersection(pipeline_pos))

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -98,11 +98,12 @@ def btb_seq(btb_seq_directory, reads_directory, results_directory):
          results_directory], cwd=btb_seq_directory)
 
 
-def performance_test(predef_snp_path, results_path, btb_seq_path, reference_path, exist_ok=False):
+def performance_test(predef_snp_path, num_snps, results_path, btb_seq_path, reference_path, exist_ok=False):
     """ Runs a performance test against the pipeline
 
         Parameters:
             predef_snp_path (str): Path to gzipped VCF (vcf.gz) file containing predefined SNPs from snippy
+            num_snps (int): Number of manually introduced SNPs, not used if predef_snp_path parameter is set
             btb_seq_path (str): Path to btb-seq code is stored
             results_path (str): Output path to performance test results
             reference_path (str): Path to reference fasta
@@ -153,7 +154,7 @@ def performance_test(predef_snp_path, results_path, btb_seq_path, reference_path
     run(["cp", "-r", btb_seq_path, btb_seq_backup_path])
 
     # Run Simulation
-    simulate_genome(predef_snp_path, reference_path, simulated_genome_path)
+    simulate_genome(predef_snp_path, reference_path, simulated_genome_path, num_snps)
     simulate_reads(fasta_path, simulated_reads_path)
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)
 
@@ -174,12 +175,13 @@ def main():
     parser.add_argument("results", help="path to performance test results")
     parser.add_argument("--btb_seq", default="../", help="path to btb-seq code")
     parser.add_argument("--predef_snps", help="optional path to VCF file with predefined SNPs", default=None)
+    parser.add_argument("--num_snps", help="number of simulated snps, overridden by predef_snps", default=16000)
     parser.add_argument("--ref", "-r", help="optional path to reference fasta", default=DEFAULT_REFERENCE_PATH)
 
     args = parser.parse_args(sys.argv[1:])
 
     # Run
-    performance_test(args.predef_snps, args.results, args.btb_seq, args.ref)
+    performance_test(args.predef_snps, args.num_snps, args.results, args.btb_seq, args.ref)
 
 if __name__ == '__main__':
     main()

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -35,6 +35,8 @@ def simulate_genome(predef_snp_path, reference_path, output_path, num_snps=16000
             "simuG.pl",
             "-refseq", reference_path,
             "-snp_vcf", predef_snp_path,
+            # below line tells simuG to also simulate predefined indels.
+            #"-indel_vcf", predef_snp_path, 
             "-prefix", output_path + "simulated"
         ])
     else:

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -5,7 +5,7 @@ import json
 import sys
 import argparse
 
-from compare_snps import analyse
+from compare_snps import analyse_basic, analyse_mask_adjust
 
 DEFAULT_REFERENCE_PATH = './Mycobacterium_bovis_AF212297_LT78304.fa'
 
@@ -164,11 +164,14 @@ def performance_test(predef_snp_path, num_snps, results_path, btb_seq_path, refe
     # HACK: this could easily break if additioanl files are present
     pipeline_directory = glob.glob(btb_seq_results_path + 'Results_simulated-reads_*')[0] + '/'
     pipeline_snps = pipeline_directory + 'snpTables/simulated.tab'
-    stats = analyse(simulated_snps, pipeline_snps)
+    stats = analyse_basic(simulated_snps, pipeline_snps)
+    stats_mask_asjust = analyse_mask_adjust(simulated_snps, pipeline_snps)
 
     # Write output
     with open(results_path + "stats.json", "w") as file:
         file.write(json.dumps(stats, indent=4))
+    with open(results_path + "stats_mask_adjust.json", "w") as file:
+        file.write(json.dumps(stats_mask_asjust, indent=4))
 
 def main():
     # Parse

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -5,7 +5,7 @@ import json
 import sys
 import argparse
 
-from compare_snps import analyse_basic, analyse_mask_adjust
+from compare_snps import analyse
 
 DEFAULT_REFERENCE_PATH = './Mycobacterium_bovis_AF212297_LT78304.fa'
 
@@ -164,8 +164,8 @@ def performance_test(predef_snp_path, num_snps, results_path, btb_seq_path, refe
     # HACK: this could easily break if additioanl files are present
     pipeline_directory = glob.glob(btb_seq_results_path + 'Results_simulated-reads_*')[0] + '/'
     pipeline_snps = pipeline_directory + 'snpTables/simulated.tab'
-    stats = analyse_basic(simulated_snps, pipeline_snps)
-    stats_mask_asjust = analyse_mask_adjust(simulated_snps, pipeline_snps)
+    stats = analyse(simulated_snps, pipeline_snps)
+    stats_mask_asjust = analyse(simulated_snps, pipeline_snps, adjust = True)
 
     # Write output
     with open(results_path + "stats.json", "w") as file:

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -29,13 +29,21 @@ def run(cmd, *args, **kwargs):
             cmd failed with exit code %i
           *****""" % (cmd, returncode))
 
-def simulate_genome(reference_path, output_path, num_snps=16000):
-    run([
-        "simuG.pl",
-        "-refseq", reference_path,
-        "-snp_count", str(num_snps),
-        "-prefix", output_path + "simulated"
-    ])
+def simulate_genome(predef_snp_path, reference_path, output_path, num_snps=16000):
+    if predef_snp_path:
+        run([
+            "simuG.pl",
+            "-refseq", reference_path,
+            "-snp_vcf", predef_snp_path,
+            "-prefix", output_path + "simulated"
+        ])
+    else:
+        run([
+            "simuG.pl",
+            "-refseq", reference_path,
+            "-snp_count", str(num_snps),
+            "-prefix", output_path + "simulated"
+        ])
 
 
 def simulate_reads(
@@ -90,10 +98,11 @@ def btb_seq(btb_seq_directory, reads_directory, results_directory):
          results_directory], cwd=btb_seq_directory)
 
 
-def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False):
+def performance_test(predef_snp_path, results_path, btb_seq_path, reference_path, exist_ok=False):
     """ Runs a performance test against the pipeline
 
         Parameters:
+            predef_snp_path (str): Path to gzipped VCF (vcf.gz) file containing predefined SNPs from snippy
             btb_seq_path (str): Path to btb-seq code is stored
             results_path (str): Output path to performance test results
             reference_path (str): Path to reference fasta
@@ -102,6 +111,7 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False)
         Returns:
             None
     """
+
     # Add trailing slash
     btb_seq_path = os.path.join(btb_seq_path, '')
     results_path = os.path.join(results_path, '')
@@ -113,6 +123,10 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False)
 
     if not os.path.isdir(btb_seq_path):
         raise Exception("Pipeline code repository not found")
+
+    if predef_snp_path and not os.path.isfile(predef_snp_path):
+    #if not os.path.isfile(predef_snp_path):
+        raise Exception("predfined SNPs file not found")
 
     # Output Directories
     simulated_genome_path = results_path + 'simulated-genome/'
@@ -139,7 +153,7 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False)
     run(["cp", "-r", btb_seq_path, btb_seq_backup_path])
 
     # Run Simulation
-    simulate_genome(reference_path, simulated_genome_path)
+    simulate_genome(predef_snp_path, reference_path, simulated_genome_path)
     simulate_reads(fasta_path, simulated_reads_path)
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)
 
@@ -159,12 +173,13 @@ def main():
         description="Performance test btb-seq code")
     parser.add_argument("results", help="path to performance test results")
     parser.add_argument("--btb_seq", default="../", help="path to btb-seq code")
-    parser.add_argument("--ref", "-r", help="path to reference fasta", default=DEFAULT_REFERENCE_PATH)
+    parser.add_argument("--predef_snps", help="optional path to VCF file with predefined SNPs", default=None)
+    parser.add_argument("--ref", "-r", help="optional path to reference fasta", default=DEFAULT_REFERENCE_PATH)
 
     args = parser.parse_args(sys.argv[1:])
 
     # Run
-    performance_test(args.results, args.btb_seq, args.ref)
+    performance_test(args.predef_snps, args.results, args.btb_seq, args.ref)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR continues development of the SNP validation pipeline.

Masked regions are subtracted from the simulated and pipeline SNPs before performing analysis calculations (TP, FP and FN and associated statistics).

stats. json also reports the number of TPs, FPs and FNs that were subtracted due to being in the masked regions.
