### PR TITLE
Saving bcf output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ commands:
       - store_artifacts:
           path: /artifacts/
 
+      - store_artifacts:
+          path: /results/
+
   build-and-push:
     parameters:
       tag:

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -192,6 +192,8 @@ process VCF2Consensus {
 
 	publishDir "$publishDir/consensus/", mode: 'copy', pattern: '*.fas'
 	publishDir "$publishDir/snpTables/", mode: 'copy', pattern: '*.tab'
+	publishDir "$publishDir/filteredBcf/", mode: 'copy', pattern: '*.bcf'
+	publishDir "$publishDir/filteredBcf/", mode: 'copy', pattern: '*.csi'
 
 	maxForks 2
 
@@ -201,9 +203,10 @@ process VCF2Consensus {
 	output:
 	tuple pair_id, file("${pair_id}_consensus.fas") into consensus
 	tuple pair_id, file("${pair_id}_snps.tab") into snpstab
+	tuple pair_id, file("${pair_id}_filtered.bcf"), file("${pair_id}_filtered.bcf.csi") into _
 
 	"""
-	vcf2Consensus.bash $ref mask.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab
+	vcf2Consensus.bash $ref mask.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf
 	"""
 }
 

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -27,9 +27,9 @@ bed=$2
 vcf=$3
 consensus=$4
 snps=$5
+bcf=$6
 
 # Filter
-bcf=filtered.bcf
 bcftools filter --IndelGap $INDEL_GAP -e "DP<${MIN_READ_DEPTH} || INFO/AD[1]/(INFO/AD[1]+INFO/AD[0]) < ${MIN_ALLELE_FREQUENCY}" $vcf -Ob -o $bcf
 bcftools index $bcf
 
@@ -45,6 +45,3 @@ echo -e 'CHROM\tPOS\tTYPE\tREF\tALT\tEVIDENCE' > $snps
 
 bcftools query -e 'TYPE="REF"' -f '%CHROM,%POS,%TYPE,%REF,%ALT,%DP4\n' $bcf |
 awk -F, '{print $1"\t"$2"\t"$3"\t"$4"\t"$5"\t"$5":"$8+$9" "$4":"$6+$7}' >> $snps
-
-# Cleanup
-rm $bcf $bcf.csi

--- a/tests/unit_tests/vcf2consensus_tests.py
+++ b/tests/unit_tests/vcf2consensus_tests.py
@@ -27,10 +27,11 @@ class Vcf2ConsensusTests(BtbTests):
             vcf_filepath,
             consensus_filepath,
             snps_filepath,
-            "test" 
+            "test.bcf"
         ])
         self.assertFileExists(consensus_filepath)
         self.assertFileExists(snps_filepath)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Filtered `.bcf` and `.bcf.csi` files generated during `vcf2consensus.bash` is saved in the results directory under a `filteredBcf/`
- CircleCI saves the results directory for each test under the `artefacts` tab. This makes it really easy to retrieve test data (the data is automatically deleted after 30 days)

![image](https://user-images.githubusercontent.com/6979169/143200499-565c1db6-54d0-4cc7-85ae-fa81a1a86667.png)
