### PR TITLE
Change extend gap penalty to 2

### DIFF
--- a/bin/map2Ref.bash
+++ b/bin/map2Ref.bash
@@ -21,6 +21,6 @@ read_2=$3
 mapped=$4
 
 # Map to reference
-bwa mem -M -t2 $ref $read_1 $read_2 |
+bwa mem -M -E 2 -t2 $ref $read_1 $read_2 |
 samtools view -@2 -ShuF 2308 - |
 samtools sort -@2 - -o $mapped


### PR DESCRIPTION
This PR increases the penalty for extending a gap (indel) from it's default value (1) to 2. 

This improves pipeline performance because it enables long complex SNPs to be called properly. With the default penalty for extending a gap, complex SNPs are incorrectly replaced with multiple indels by bwa because these incur a lower overall penalty. Increasing the extending gap penalty means the relative penalty for complex SNPs is lower and this type of variant is correctly favoured.   