### PR TITLE
Pipefail

### DIFF
--- a/bin/assignClusterCss.bash
+++ b/bin/assignClusterCss.bash
@@ -3,6 +3,9 @@
 # Assigns cluster by matching patterns of cluster specific SNPs
 # Compares SNPs identified in vcf file to lists in reference table
 
+# Error handling
+set -eo pipefail
+
 pair_id=$1
 discrimPos=$2
 stage1pat=$3
@@ -13,10 +16,6 @@ min_qual_snp=$7
 min_qual_nonsnp=$8
 pypath=$9
 ref=$10
-
-# Error handling
-set -e
-set pipefail
 
 bcftools view -R ${discrimPos} -O v -o ${pair_id}.discrimPos.vcf ${pair_id}.vcf.gz
 python3 $pypath/Stage1-test.py ${pair_id}_stats.csv ${stage1pat} $ref test ${min_mean_cov} ${min_cov_snp} ${alt_prop_snp} ${min_qual_snp} ${min_qual_nonsnp} ${pair_id}.discrimPos.vcf

--- a/bin/assignClusterCss.bash
+++ b/bin/assignClusterCss.bash
@@ -14,6 +14,10 @@ min_qual_nonsnp=$8
 pypath=$9
 ref=$10
 
+# Error handling
+set -e
+set pipefail
+
 bcftools view -R ${discrimPos} -O v -o ${pair_id}.discrimPos.vcf ${pair_id}.vcf.gz
 python3 $pypath/Stage1-test.py ${pair_id}_stats.csv ${stage1pat} $ref test ${min_mean_cov} ${min_cov_snp} ${alt_prop_snp} ${min_qual_snp} ${min_qual_nonsnp} ${pair_id}.discrimPos.vcf
 mv _stage1.csv ${pair_id}_stage1.csv

--- a/bin/deduplicate.bash
+++ b/bin/deduplicate.bash
@@ -14,15 +14,14 @@
 #%    deduplicated_1  output path to first deduplicated file
 #%    deduplicated_2  output path to second deduplicated file
 
+# Error handling
+set -eo pipefail
+
 # Inputs
 pair_1=$1
 pair_2=$2
 deduplicated_1=$3
 deduplicated_2=$4
-
-# Error handling
-set -e
-set pipefail
 
 nl=$'\n'
 

--- a/bin/deduplicate.bash
+++ b/bin/deduplicate.bash
@@ -20,6 +20,10 @@ pair_2=$2
 deduplicated_1=$3
 deduplicated_2=$4
 
+# Error handling
+set -e
+set pipefail
+
 nl=$'\n'
 
 # Unzip

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -5,11 +5,13 @@
 # Bracken parses the output which is then sorted to generate a top 20 list of species
 # Presence / absence of M.bovis is also determined by parsing Bracken output
 
-set -e
-
 pair_id=$1
 kraken2db=$2
 lowmem=$3
+
+# Error handling
+set -e
+set pipefail
 
 outcome=$(cat outcome.txt)
 if [ $outcome != "Pass" ]; then

--- a/bin/idNonBovis.bash
+++ b/bin/idNonBovis.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Error handling
+set -eo pipefail
+
 # Identify any non-M.bovis samples using kraken
 # Samples with flag != 'Pass' are processed to detemine which microbe(s) are present 
 # Bracken parses the output which is then sorted to generate a top 20 list of species
@@ -8,10 +11,6 @@
 pair_id=$1
 kraken2db=$2
 lowmem=$3
-
-# Error handling
-set -e
-set pipefail
 
 outcome=$(cat outcome.txt)
 if [ $outcome != "Pass" ]; then

--- a/bin/map2Ref.bash
+++ b/bin/map2Ref.bash
@@ -14,15 +14,14 @@
 #%    read_2          path to second input fastq read file
 #%    mapped          path to output mapped bam file
 
+# Error handling
+set -eo pipefail
+
 # Args
 ref=$1
 read_1=$2
 read_2=$3
 mapped=$4
-
-# Error handling
-set -e
-set pipefail
 
 # Map to reference
 bwa mem -M -E 2 -t2 $ref $read_1 $read_2 |

--- a/bin/map2Ref.bash
+++ b/bin/map2Ref.bash
@@ -20,6 +20,10 @@ read_1=$2
 read_2=$3
 mapped=$4
 
+# Error handling
+set -e
+set pipefail
+
 # Map to reference
 bwa mem -M -E 2 -t2 $ref $read_1 $read_2 |
 samtools view -@2 -ShuF 2308 - |

--- a/bin/mask.bash
+++ b/bin/mask.bash
@@ -16,6 +16,9 @@
 #%    regions      output path to regions file (sites to keep)
 #%    allsites     input path to allsites bed file
 
+# Error handling
+set -eo pipefail
+
 # Inputs
 rpt_mask=$1
 vcf=$2
@@ -26,10 +29,6 @@ allsites=$6
 MIN_READ_DEPTH=$7
 MIN_ALLELE_FREQUENCY_ALT=$8
 MIN_ALLELE_FREQUENCY_REF=$9
-
-# Error handling
-set -e
-set pipefail
 
 # Construct a mask: 
 # mask regions which don't have {sufficient evidence for alt AND sufficient evidence for the REF}

--- a/bin/mask.bash
+++ b/bin/mask.bash
@@ -27,6 +27,10 @@ MIN_READ_DEPTH=$7
 MIN_ALLELE_FREQUENCY_ALT=$8
 MIN_ALLELE_FREQUENCY_REF=$9
 
+# Error handling
+set -e
+set pipefail
+
 # Construct a mask: 
 # mask regions which don't have {sufficient evidence for alt AND sufficient evidence for the REF}
 bcftools filter -i "(ALT!='.' && INFO/AD[1] < ${MIN_READ_DEPTH} && INFO/AD[0]/(INFO/AD[0]+INFO/AD[1]) <= ${MIN_ALLELE_FREQUENCY_REF}) ||

--- a/bin/readStats.bash
+++ b/bin/readStats.bash
@@ -10,6 +10,10 @@
 
 pair_id=$1
 
+# Error handling
+set -e
+set pipefail
+
 # Count reads in each catagory; in fastq files each read consists of four lines
 
     raw_R1=$(( $(zcat ${pair_id}_*_R1_*.fastq.gz | wc -l) / 4 )) # counts number of reads in file

--- a/bin/readStats.bash
+++ b/bin/readStats.bash
@@ -5,14 +5,11 @@
 #  Created by ellisrichardj on 10/10/2019.
 #  
 
-#  Define inputs - sample name
-
-
-pair_id=$1
-
 # Error handling
-set -e
-set pipefail
+set -eo pipefail
+
+#  Define inputs - sample name
+pair_id=$1
 
 # Count reads in each catagory; in fastq files each read consists of four lines
 

--- a/bin/trim.bash
+++ b/bin/trim.bash
@@ -16,15 +16,14 @@
 #%    trimmed_1       output path to first trimmed fastq file
 #%    trimmed_2       output path to second trimmed fafstq file
 
+# Error handling
+set -eo pipefail
+
 adapters=$1
 read_1=$2
 read_2=$3
 trimmed_1=$4
 trimmed_2=$5
-
-# Error handling
-set -e
-set pipefail
 
 # Error if adapters file does not exist, as trimmomatic won't!
 if [[ ! -f $adapters ]]; then

--- a/bin/trim.bash
+++ b/bin/trim.bash
@@ -22,6 +22,10 @@ read_2=$3
 trimmed_1=$4
 trimmed_2=$5
 
+# Error handling
+set -e
+set pipefail
+
 # Error if adapters file does not exist, as trimmomatic won't!
 if [[ ! -f $adapters ]]; then
     echo $adapter does not exist

--- a/bin/varCall.bash
+++ b/bin/varCall.bash
@@ -13,16 +13,14 @@
 #%    bam             path to first input fastq read file
 #%    vcf             path to output vcf.gz file
 
+# Error handling
+set -eo pipefail
 
 # Determines where the sample differs from the reference genome
 
 ref=$1
 bam=$2
 vcf=$3
-
-# Error handling
-set -e
-set pipefail
 
 samtools index $bam
 bcftools mpileup -Q 10 -a INFO/AD -Ou -f $ref "$bam" |

--- a/bin/varCall.bash
+++ b/bin/varCall.bash
@@ -20,6 +20,10 @@ ref=$1
 bam=$2
 vcf=$3
 
+# Error handling
+set -e
+set pipefail
+
 samtools index $bam
 bcftools mpileup -Q 10 -a INFO/AD -Ou -f $ref "$bam" |
 bcftools call -mf GQ - -Ou |

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -29,7 +29,9 @@ snps=$6
 bcf=$7
 MIN_ALLELE_FREQUENCY=$8
 
+# Error handling
 set -e
+set pipefail
 
 # handle the case when the regions file is empty otherwise bcftools filter will faile
 if [ ! -s $regions ]; then

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -17,6 +17,8 @@
 #%    snps         output path to snps tab file (.tab)
 #%    bcf          output path to filtered bcf file (.bcf)
 
+# Error handling
+set -eo pipefail
 
 #=======
 # Inputs
@@ -28,10 +30,6 @@ consensus=$5
 snps=$6
 bcf=$7
 MIN_ALLELE_FREQUENCY=$8
-
-# Error handling
-set -e
-set pipefail
 
 # handle the case when the regions file is empty otherwise bcftools filter will faile
 if [ ! -s $regions ]; then


### PR DESCRIPTION
This PR resolves a unit testing bug whereby errors in mask.bash were being left uncaught. This was because the error was raised within a pipe on a bash script. To resolve this, and prevent similar issues arising in other nf processes - `pipefail` and `set -e` have been added to all nextflow bash scripts.  