### PR TITLE
Unmasked output v2

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -176,10 +176,10 @@ process Mask {
 	tuple pair_id, file("called.vcf"), file("called.vcf.csi"), file("mapped.bam") from mask_input
 
 	output:
-	tuple pair_id, file("mask.bed"), file("nonmasked-regions.bed") into maskbed
+	tuple pair_id, file("mask.bed"), file("filter.bed"), file("nonmasked-regions.bed") into maskbed
 
 	"""
-	mask.bash $rptmask called.vcf mask.bed nonmasked-regions.bed mapped.bam $allsites $params.MIN_READ_DEPTH $params.MIN_ALLELE_FREQUENCY_ALT $params.MIN_ALLELE_FREQUENCY_REF
+	mask.bash $rptmask called.vcf mask.bed filter.bed nonmasked-regions.bed mapped.bam $allsites $params.MIN_READ_DEPTH $params.MIN_ALLELE_FREQUENCY_ALT $params.MIN_ALLELE_FREQUENCY_REF
 	"""
 }
 
@@ -203,7 +203,7 @@ process VCF2Consensus {
 	maxForks 2
 
 	input:
-	tuple pair_id, file("mask.bed"), file("nonmasked-regions.bed"), file("variant.vcf.gz"),	file("variant.vcf.gz.csi") from vcf_bed
+	tuple pair_id, file("mask.bed"), file("filter.bed"), file("nonmasked-regions.bed"), file("variant.vcf.gz"),	file("variant.vcf.gz.csi") from vcf_bed
 
 	output:
 	tuple pair_id, file("${pair_id}_consensus.fas"), file("${pair_id}_unmasked_consensus.fas") into consensus
@@ -211,7 +211,7 @@ process VCF2Consensus {
 	tuple pair_id, file("${pair_id}_filtered.bcf"), file("${pair_id}_filtered.bcf.csi") into _
 
 	"""
-	vcf2Consensus.bash $ref mask.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf ${pair_id}_unmasked_consensus.fas $params.MIN_ALLELE_FREQUENCY_ALT 
+	vcf2Consensus.bash $ref mask.bed filter.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf ${pair_id}_unmasked_consensus.fas $params.MIN_ALLELE_FREQUENCY_ALT 
 	"""
 }
 

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -196,6 +196,7 @@ process VCF2Consensus {
     tag "$pair_id"
 
 	publishDir "$publishDir/consensus/", mode: 'copy', pattern: '*.fas'
+	publishDir "$publishDir/unmaksed_consensus/", mode: 'copy', pattern: '*_unmasked.fas'
 	publishDir "$publishDir/snpTables/", mode: 'copy', pattern: '*.tab'
 	publishDir "$publishDir/filteredBcf/", mode: 'copy', pattern: '*.bcf'
 	publishDir "$publishDir/filteredBcf/", mode: 'copy', pattern: '*.csi'
@@ -203,15 +204,16 @@ process VCF2Consensus {
 	maxForks 2
 
 	input:
-	tuple pair_id, file("mask.bed"), file("filter.bed"), file("nonmasked-regions.bed"), file("variant.vcf.gz"),	file("variant.vcf.gz.csi") from vcf_bed
+	tuple pair_id, file("mask.bed"), file("filter.bed"), file("nonmasked-regions.bed"), file("variant.vcf.gz"), file("variant.vcf.gz.csi") from vcf_bed
 
 	output:
-	tuple pair_id, file("${pair_id}_consensus.fas"), file("${pair_id}_unmasked_consensus.fas") into consensus
+	tuple pair_id, file("${pair_id}_consensus.fas") into consensus
+	tuple pair_id, file("${pair_id}_consensus_unmasked.fas") into unmasked_consensus
 	tuple pair_id, file("${pair_id}_snps.tab") into snpstab
 	tuple pair_id, file("${pair_id}_filtered.bcf"), file("${pair_id}_filtered.bcf.csi") into _
 
 	"""
-	vcf2Consensus.bash $ref mask.bed filter.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf ${pair_id}_unmasked_consensus.fas $params.MIN_ALLELE_FREQUENCY_ALT 
+	vcf2Consensus.bash $ref mask.bed filter.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf ${pair_id}_consensus_unmasked.fas $params.MIN_ALLELE_FREQUENCY_ALT 
 	"""
 }
 

--- a/bin/mask.bash
+++ b/bin/mask.bash
@@ -12,7 +12,8 @@
 #% INPUTS
 #%    rpt_mask     path to repeat mask
 #%    vcf          input path to vcf file
-#%    masked       output path to masked bed file
+#%    masked       output path to masked bed file INCLUDING rpt mask
+#%    filtered     output path to masked bed file EXCLUDING rpt mask
 #%    regions      output path to regions file (sites to keep)
 #%    allsites     input path to allsites bed file
 
@@ -20,12 +21,13 @@
 rpt_mask=$1
 vcf=$2
 masked=$3
-regions=$4
-bam=$5
-allsites=$6
-MIN_READ_DEPTH=$7
-MIN_ALLELE_FREQUENCY_ALT=$8
-MIN_ALLELE_FREQUENCY_REF=$9
+filtered=$4
+regions=$5
+bam=$6
+allsites=$7
+MIN_READ_DEPTH=$8
+MIN_ALLELE_FREQUENCY_ALT=$9
+MIN_ALLELE_FREQUENCY_REF=${10}
 
 # Construct a mask: 
 # mask regions which don't have {sufficient evidence for alt AND sufficient evidence for the REF}
@@ -40,6 +42,11 @@ bedtools genomecov -bga -ibam $bam | grep -w "0\$" | cut -f -3 > zerocov.bed
 cat quality-mask.bed zerocov.bed $rpt_mask | 
 sort -k1,1 -k2,2n |
 bedtools merge > $masked
+
+# exclude rpt mask
+cat quality-mask.bed zerocov.bed | 
+sort -k1,1 -k2,2n |
+bedtools merge > $filtered
 
 # Make bedfile of sites to keep
 bedtools subtract -a $allsites -b $masked > $regions

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -52,6 +52,7 @@ name="${base_name%%.*}"
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $mask $bcf |
 sed "/^>/ s/.*/>${name}/" > $consensus
 
+# TODO test unmasked_consensus
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $filter $bcf |
 sed "/^>/ s/.*/>${name}/" > $unmasked_consensus
 

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -22,13 +22,14 @@
 # Inputs
 ref=$1
 mask=$2
-regions=$3
-vcf=$4
-consensus=$5
-snps=$6
-bcf=$7
-unmasked_consensus=$8
-MIN_ALLELE_FREQUENCY=$9
+filter=$3
+regions=$4
+vcf=$5
+consensus=$6
+snps=$7
+bcf=$8
+unmasked_consensus=$9
+MIN_ALLELE_FREQUENCY=${10}
 
 
 set -e
@@ -51,7 +52,7 @@ name="${base_name%%.*}"
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $mask $bcf |
 sed "/^>/ s/.*/>${name}/" > $consensus
 
-bcftools consensus -f ${ref} -e 'TYPE="indel"' $bcf |
+bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $filter $bcf |
 sed "/^>/ s/.*/>${name}/" > $unmasked_consensus
 
 # Write SNPs table

--- a/tests/unit_tests/mask_tests.py
+++ b/tests/unit_tests/mask_tests.py
@@ -16,6 +16,7 @@ class MaskTests(BtbTests):
         vcf_filepath = self.temp_dirname+'edge-cases.vcf'
         vcf_gz_filepath = self.temp_dirname+'edge-cases.vcf.gz'
         masked_filepath = self.temp_dirname+'masked.bed'
+        filtered_filepath = self.temp_dirname+'filtered.bed'
         regions_filepath = self.temp_dirname+'regions.bed'
         sam_filepath = self.temp_dirname+'edge-cases.sam'
         bam_filepath = self.temp_dirname+'edge-cases.bam'
@@ -31,6 +32,7 @@ class MaskTests(BtbTests):
             rpt_mask_filepath, 
             vcf_gz_filepath, 
             masked_filepath, 
+            filtered_filepath, 
             regions_filepath, 
             bam_filepath,
             self.allsites, 

--- a/tests/unit_tests/vcf2consensus_tests.py
+++ b/tests/unit_tests/vcf2consensus_tests.py
@@ -29,7 +29,7 @@ class Vcf2ConsensusTests(BtbTests):
 
         # Outputs
         consensus_filepath = self.temp_dirname + 'consensus.fas'
-        unmasked_consensus_filepath = self.temp_dirname + 'unmasked_consensus.fas'
+        unmasked_consensus_filepath = self.temp_dirname + 'consensus_unmaksed.fas'
         snps_filepath = self.temp_dirname + 'snps.tab'
 
         # Test

--- a/tests/unit_tests/vcf2consensus_tests.py
+++ b/tests/unit_tests/vcf2consensus_tests.py
@@ -12,6 +12,7 @@ class Vcf2ConsensusTests(BtbTests):
         # Copy data
         ref_filepath = self.temp_dirname + 'ref.fas'
         masked_filepath = self.temp_dirname + 'masked.bed'
+        filtered_filepath = self.temp_dirname + 'filtered.bed'
         vcf_filepath = self.temp_dirname + 'edge-cases.vcf'
         vcf_gz_filepath = self.temp_dirname+'edge-cases.vcf.gz'
         regions_filepath = self.temp_dirname + 'regions.bed'
@@ -19,6 +20,7 @@ class Vcf2ConsensusTests(BtbTests):
 
         shutil.copy('./tests/data/tinyref.fas', ref_filepath) 
         shutil.copy('./tests/data/edge-cases.bed', masked_filepath) 
+        shutil.copy('./tests/data/edge-cases.bed', filtered_filepath) 
         shutil.copy('./tests/data/edge-cases.vcf', vcf_filepath) 
         shutil.copy('./tests/data/edge-cases_regions.bed', regions_filepath) 
 
@@ -34,6 +36,7 @@ class Vcf2ConsensusTests(BtbTests):
         self.assertBashScript(0, ['./bin/vcf2Consensus.bash', 
             ref_filepath, 
             masked_filepath,
+            filtered_filepath,
             regions_filepath,
             vcf_gz_filepath,
             consensus_filepath,


### PR DESCRIPTION
This PR fixes a bug in the unmasked consensus output.

Prior to the fix, the unmasked consensus output also excluded filtering of sites which did not fall within the base mask. 

The unmasked output now includes filtering by producing a "`filtered.bed`" file in `mask.bash` which includes filtered sites but excludes sites in the rpt/base mask. `filtered.bed` is applied to `unmasked_consensus` in `vcf2consensus.bash`.