### PR TITLE
Removing the unmasked consensus output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ commands:
       - setup_remote_docker
       - run: |
           TAG=<< parameters.tag >>
-          docker build -t aaronsfishman/bov-tb:$TAG -f ./docker/Dockerfile .
+          docker build -t aphacsubot/btb-seq:$TAG -f ./docker/Dockerfile .
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-          docker push aaronsfishman/bov-tb:$TAG
+          docker push aphacsubot/btb-seq:$TAG
 
 # Run tests under BovTB-nf/tests/jobs/ and store artifacts
 jobs:
@@ -100,7 +100,7 @@ jobs:
 executors:
   nf-pipeline:
     docker:
-      - image: "aaronsfishman/bov-tb:$CIRCLE_BRANCH"
+      - image: "aphacsubot/btb-seq:$CIRCLE_BRANCH"
 
 # Orchestrates the validation tests 
 workflows:

--- a/Readme.md
+++ b/Readme.md
@@ -45,11 +45,11 @@ To run a batch from the terminal
 
 **Note:** While running from the terminal is the easiest method for developers and data analysts, the pipeline can also be run from docker. This method has the benefit of working across platforms while guaranteeing consistency with automated tests (see below). 
 
-A docker image containing all required dependancies is provided [here](https://hub.docker.com/r/aaronsfishman/bov-tb). 
+A docker image containing all required dependancies is provided [here](https://hub.docker.com/r/aphacsubot/btb-seq). 
 
 This pull the latest image (if it's not already fetched) from dockerhub and run the container on data
 ```
-sudo docker run --rm -it -v /ABS/PATH/TO/READS/:/reads/ -v /ABS/PATH/TO/RESULTS/:/results/ aaronsfishman/bov-tb
+sudo docker run --rm -it -v /ABS/PATH/TO/READS/:/reads/ -v /ABS/PATH/TO/RESULTS/:/results/ aphacsubot/btb-seq
 ```
 
 #### Build docker image from source 


### PR DESCRIPTION
This PR removes code which was saving the unmasked consensus output because it was not implemented correctly.

Unfortunately GitHub hasn't picked up on the correct file changes, I think because I cherry-picked old commits rather than manually amending the code and making new commits. 

The files which have changed are:

`bTB-WGS_process.nf`
`vcf2Consensus.bash`
`vcf2consensus_tests.py`