### PR TITLE
Fix s3 output

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -78,6 +78,8 @@ FirstFile = file( params.reads ).first()
 	params.DataDir = TopDir.last()
 	params.today = new Date().format('ddMMMYY')
 
+seqplate = "${params.DataDir}"
+
 publishDir = "$params.outdir/Results_${params.DataDir}_${params.today}/"
 
 /* remove duplicates from raw data
@@ -334,14 +336,14 @@ process CombineOutput {
 	publishDir "$params.outdir/Results_${params.DataDir}_${params.today}", mode: 'copy', pattern: '*.csv'
 	
 	input:
-	file('Assigned.csv') from Assigned
-	file('Qbovis.csv') from Qbovis
+	file('assigned_csv') from Assigned
+	file('qbovis_csv') from Qbovis
 
 	output:
 	file('*.csv') into FinalOut
 
 	"""
-	combineCsv.py Assigned.csv Qbovis.csv ${params.DataDir}
+	combineCsv.py assigned_csv qbovis_csv $seqplate
 	"""
 }
 

--- a/bin/combineCsv.py
+++ b/bin/combineCsv.py
@@ -16,8 +16,7 @@ def combine(assigned_csv, bovis_csv, seq_run, commitId, read_threshold, abundanc
     user = getpass.getuser()
     scriptpath = os.path.dirname(os.path.abspath(__file__))
     repo = git.Repo(scriptpath, search_parent_directories=True)
-    #commit = repo.head.object.__str__()
-
+    
     #Read Assigned Clade csv and replace blank cells  with 'NA'
     assigned_df = pd.read_csv(assigned_csv)
     assignedround_df = assigned_df.round(2)


### PR DESCRIPTION
There has been an issue where if the input data directory was set as an s3 URI the final `CombineOutput` process would fail, meaning that the results table was never generated.  This is linked to the issue I raised with nextflow here: https://github.com/nextflow-io/nextflow/issues/2502#issue-1083456585. 

After a bit if digging and lots of testing, the issue was caused by the source data parent directory being recognised as an s3 object when collected as a parameter `params.DataDir` in line 78 of bTB-WGS_process.nf.  The process couldn't be initiated with this for some reason, but could if this was a local path.  I still think this is a nextflow bug, but have fixed the issue in our pipeline by defining a variable from `params.DataDir` (turning what was perceived as a path into a string) which can then be used as an alternate input for the `CombineOutput` process.

This now fixes things so that an EC2 instance can run the pipeline without the need for separate copying of input files to local storage, or the output files back to s3.  We can now run on a naïve instance with a simple command (tested on my ranch machine): 

`~/nextflow run APHA-CSU/btb-seq -with-docker aphacsubot/btb-seq -r Fixs3Output --reads='s3://s3-csu-001/SB4030/M02410_5271/*_{S*_R1,S*_R2}*.fastq.gz' --outdir='s3://s3-staging-area/RichardEllis/'`

The only requirements are to have nextflow and docker installed.  Nextflow will pull the repo (and I have defined the specific branch with `-r`) and use the docker image specified.   I think this should simplify the reprocess and hopefully make batch implementation much simpler.  This is now much closer to nextflow's ideal _modus operandi_ 