### PR TITLE
Speedup consensus

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -215,7 +215,7 @@ process VCF2Consensus {
 	tuple pair_id, file("${pair_id}_filtered.bcf"), file("${pair_id}_filtered.bcf.csi") into _
 
 	"""
-	vcf2Consensus.bash $ref mask.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf ${pair_id}_unmasked_consensus.fas $params.MIN_ALLELE_FREQUENCY_ALT 
+	vcf2Consensus.bash $ref mask.bed nonmasked-regions.bed variant.vcf.gz ${pair_id}_consensus.fas ${pair_id}_snps.tab ${pair_id}_filtered.bcf $params.MIN_ALLELE_FREQUENCY_ALT 
 	"""
 }
 

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -210,7 +210,7 @@ process VCF2Consensus {
 	tuple pair_id, file("mask.bed"), file("nonmasked-regions.bed"), file("variant.vcf.gz"),	file("variant.vcf.gz.csi") from vcf_bed
 
 	output:
-	tuple pair_id, file("${pair_id}_consensus.fas"), file("${pair_id}_unmasked_consensus.fas") into consensus
+	tuple pair_id, file("${pair_id}_consensus.fas") into consensus
 	tuple pair_id, file("${pair_id}_snps.tab") into snpstab
 	tuple pair_id, file("${pair_id}_filtered.bcf"), file("${pair_id}_filtered.bcf.csi") into _
 

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -160,7 +160,7 @@ process VarCall {
 	tuple pair_id, file("${pair_id}.vcf.gz"), file("${pair_id}.vcf.gz.csi") into vcf, vcf2,	vcf4mask
 
 	"""
-	varCall.bash $ref mapped.bam ${pair_id}.vcf.gz
+	varCall.bash $ref mapped.bam ${pair_id}.vcf.gz $params.MAP_QUAL $params.BASE_QUAL $params.PLOIDY
 	"""
 }
 

--- a/bin/varCall.bash
+++ b/bin/varCall.bash
@@ -21,9 +21,12 @@ set -eo pipefail
 ref=$1
 bam=$2
 vcf=$3
+MAP_QUAL=$4
+BASE_QUAL=$5
+PLOIDY=$6
 
 samtools index $bam
-bcftools mpileup -Q 10 -a INFO/AD -Ou -f $ref "$bam" |
-bcftools call -mf GQ - -Ou |
-bcftools norm -f $ref - -Oz -o "$vcf"
+bcftools mpileup -q $MAP_QUAL -Q $BASE_QUAL -a INFO/AD -Ou -f $ref "$bam" |
+    bcftools call --ploidy $PLOIDY -mf GQ - -Ou |
+    bcftools norm -f $ref - -Oz -o "$vcf"
 bcftools index $vcf

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -51,9 +51,6 @@ name="${base_name%%.*}"
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $mask $bcf |
 sed "/^>/ s/.*/>${name}/" > $consensus
 
-bcftools consensus -f ${ref} -e 'TYPE="indel"' $bcf |
-sed "/^>/ s/.*/>${name}/" > $unmasked_consensus
-
 # Write SNPs table
 echo -e 'CHROM\tPOS\tTYPE\tREF\tALT\tEVIDENCE' > $snps
 

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -29,8 +29,7 @@ vcf=$4
 consensus=$5
 snps=$6
 bcf=$7
-unmasked_consensus=$8
-MIN_ALLELE_FREQUENCY=$9
+MIN_ALLELE_FREQUENCY=$8
 
 
 # handle the case when the regions file is empty otherwise bcftools filter will faile

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -40,7 +40,7 @@ fi
 
 # Select SNPs
 # applies filter/mask and chooses SNP sites
-bcftools filter -R $regions -i "ALT!='.' && INFO/AD[1]/(INFO/AD[0]+INFO/AD[1]) >= ${MIN_ALLELE_FREQUENCY}" $vcf -Ob -o $bcf
+bcftools filter -i "ALT!='.' && INFO/AD[1]/(INFO/AD[0]+INFO/AD[1]) >= ${MIN_ALLELE_FREQUENCY}" $vcf -Ob -o $bcf
 bcftools index $bcf
 
 # Call Consensus

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,4 +41,4 @@ params.MIN_ALLELE_FREQUENCY_REF = 0.7
 
 /* location of dependancies */
 
-params.kraken2db = "/home/richardellis/biotools/Kraken2/db/minikraken2_v1_8GB/"
+params.kraken2db = "/opt/Kraken2/db/minikraken2_v1_8GB/"

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,10 +24,15 @@ params.pypath = "$baseDir/pyscripts/"
 
 /* quality thresholds */
 env.min_mean_cov = 8
-env.min_cov_snp = 5 
-env.alt_prop_snp = 0.2 
+env.min_cov_snp = 5
+env.alt_prop_snp = 0.2
 env.min_qual_snp = 150
 env.min_qual_nonsnp = 0
+
+/* quality thresholds (variant calling) */
+params.MAP_QUAL = 0
+params.BASE_QUAL = 10
+params.PLOIDY = "GRCh37"
 
 /* quality thresholds (snp filtering) */
 params.MIN_READ_DEPTH = 8
@@ -36,4 +41,4 @@ params.MIN_ALLELE_FREQUENCY_REF = 0.7
 
 /* location of dependancies */
 
-params.kraken2db = "/opt/Kraken2/db/minikraken2_v1_8GB/"
+params.kraken2db = "/home/richardellis/biotools/Kraken2/db/minikraken2_v1_8GB/"

--- a/tests/unit_tests/varCall_tests.py
+++ b/tests/unit_tests/varCall_tests.py
@@ -12,6 +12,9 @@ class VarCallTests(BtbTests):
         sam_path = self.temp_dirname + '/tinymatch.sam'
         bam_path = self.temp_dirname + '/tinymatch.bam'
         output = self.temp_dirname + 'variants.vcf.gz'
+        map_qual = str(0)
+        base_qual = str(10)
+        ploidy = str('GRCh37')
 
         # Copy test data
         shutil.copy2('./tests/data/tinymatch.sam', sam_path)
@@ -20,7 +23,7 @@ class VarCallTests(BtbTests):
         self.sam_to_bam(sam_path, bam_path)
 
         # Pass case
-        self.assertBashScript(0, ['./bin/varCall.bash', self.ref_path, bam_path, output])
+        self.assertBashScript(0, ['./bin/varCall.bash', self.ref_path, bam_path, output, map_qual, base_qual, ploidy])
         self.assertFileExists(output)
 
         # Unzip

--- a/tests/unit_tests/vcf2consensus_tests.py
+++ b/tests/unit_tests/vcf2consensus_tests.py
@@ -27,7 +27,6 @@ class Vcf2ConsensusTests(BtbTests):
 
         # Outputs
         consensus_filepath = self.temp_dirname + 'consensus.fas'
-        unmasked_consensus_filepath = self.temp_dirname + 'unmasked_consensus.fas'
         snps_filepath = self.temp_dirname + 'snps.tab'
 
         # Test
@@ -37,7 +36,6 @@ class Vcf2ConsensusTests(BtbTests):
             regions_filepath,
             vcf_gz_filepath,
             consensus_filepath,
-            unmasked_consensus_filepath,
             snps_filepath,
             bcf_filepath,
             str(0.8)


### PR DESCRIPTION
During testing I noticed that the vcf2consensus process was taking considerably longer than the existing prod version.  For the 11 samples I was looking at the difference was 30 minutes cf. 12 minutes, so quite significant. To fix this I have I have removed the process which restricts the initial bcftools filter to the unmasked regions (`-R $regions`) as this was the part that was taking additional time (for some reason the combination of `-R` and `-i` is slow).  The consensus calling step uses '-m $mask' to the same effect and the snp tables uses `-R $regions`, so effectively its use in bcftools filter was unnecessary.  Linked to this I'm not sure if we need to retain the bcf file in the output directory, so perhaps can be removed in a future PR.

I've also added in the capability to define some of the mapping parameters in the config file rather than having them set in the scripts themselves