### PR TITLE
Fix fasta header name

### DIFF
--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -44,7 +44,8 @@ bcftools filter -i "ALT!='.' && INFO/AD[1]/(INFO/AD[0]+INFO/AD[1]) >= ${MIN_ALLE
 bcftools index $bcf
 
 # Call Consensus
-file_name="$(basename $consensus)"
+file="$(basename $consensus)"
+file_name=${file%%.*}
 name="${file_name%%_*}"
 
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $mask $bcf |

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -44,8 +44,8 @@ bcftools filter -i "ALT!='.' && INFO/AD[1]/(INFO/AD[0]+INFO/AD[1]) >= ${MIN_ALLE
 bcftools index $bcf
 
 # Call Consensus
-base_name=`basename $consensus`
-name="${base_name%%.*}"
+file_name="$(basename $consensus)"
+name="${file_name%%_*}"
 
 bcftools consensus -f ${ref} -e 'TYPE="indel"' -m $mask $bcf |
 sed "/^>/ s/.*/>${name}/" > $consensus


### PR DESCRIPTION
This PR just removes the '__consensus_' from the header line of the fasta output files.  This makes the downstream analysis a bit cleaner as '__concensus_' will no longer appear in snp-sites, snp-dists and tree outputs.