### PR TITLE
Fix permissions for docker work directory cleanup

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -361,4 +361,8 @@ workflow.onComplete {
 		log.info "Nextflow Version:	$workflow.nextflow.version"
 		log.info "Duration:		$workflow.duration"
 		log.info "Output Directory:	$params.outdir/Results_${params.DataDir}_${params.today}"
+		stage = file("$workflow.workDir/stage")
+		tmp = file("$workflow.workDir/tmp")
+		stage.deleteDir()
+		tmp.deleteDir()
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ NXF_DEFAULT_DSL=1
 
 /* remove work directory pipeline completes sucessfully */ 
 cleanup = true
+docker { fixOwnership = 'true' }
 
 /* location of reference information */
 


### PR DESCRIPTION
Added a line to the config file that fixes ownership of files when Nextflow is run `-with-docker`.  Also as the `cleanup` process did not delete staged files or those in the `work/tmp` directory these are now removed as part of the `onComplete` procedure.