### PR TITLE
Add result location

### DIFF
--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -221,6 +221,7 @@ process VCF2Consensus {
 		${pair_id}_filtered.bcf \
 		$params.MIN_ALLELE_FREQUENCY_ALT \
 		$pair_id
+		$publishDir
 	"""
 }
 

--- a/bTB-WGS_process.nf
+++ b/bTB-WGS_process.nf
@@ -220,7 +220,7 @@ process VCF2Consensus {
 		${pair_id}_snps.tab \
 		${pair_id}_filtered.bcf \
 		$params.MIN_ALLELE_FREQUENCY_ALT \
-		$pair_id
+		$pair_id \
 		$publishDir
 	"""
 }

--- a/bin/combineCsv.py
+++ b/bin/combineCsv.py
@@ -19,10 +19,12 @@ def combine(assigned_csv, bovis_csv, ncount_csv, seq_run, commitId, read_thresho
     
     #Read Assigned Clade csv and replace blank cells  with 'NA'
     assigned_df = pd.read_csv(assigned_csv)
+    assigned_df['Sample'].astype(object, inplace = True)
     assignedround_df = assigned_df.round(2)
 
     #Read ncount csv
     ncount_df = pd.read_csv(ncount_csv)
+    ncount_df['Sample'].astype(object, inplace = True)
 
     # Read BovPos csv and change ID to either 'Negative' or 'Mycobacterium bovis',
     # depending on number and relative abundance of M.bovis reads.
@@ -30,6 +32,7 @@ def combine(assigned_csv, bovis_csv, ncount_csv, seq_run, commitId, read_thresho
     # Fill empty value cells with zero 
     # TODO: Potential that not all scenarios are covered by the options below, so need to add default ID outcome
     bovis_df = pd.read_csv(bovis_csv)
+    bovis_df['Sample'].astype(object, inplace = True)
     qbovis_df = bovis_df.round(2)
     qbovis_df.loc[(qbovis_df['TotalReads'] >= read_threshold) & (qbovis_df['Abundance'] >= abundance_threshold), 'ID'] = 'Mycobacterium bovis'
     qbovis_df.loc[(qbovis_df['TotalReads'] < read_threshold) & (qbovis_df['Abundance'] < abundance_threshold), 'ID'] = 'Negative'

--- a/bin/combineCsv.py
+++ b/bin/combineCsv.py
@@ -19,12 +19,12 @@ def combine(assigned_csv, bovis_csv, ncount_csv, seq_run, commitId, read_thresho
     
     #Read Assigned Clade csv and replace blank cells  with 'NA'
     assigned_df = pd.read_csv(assigned_csv)
-    assigned_df['Sample'].astype(object, inplace = True)
+    assigned_df['Sample']=assigned_df['Sample'].astype(object)
     assignedround_df = assigned_df.round(2)
 
     #Read ncount csv
     ncount_df = pd.read_csv(ncount_csv)
-    ncount_df['Sample'].astype(object, inplace = True)
+    ncount_df['Sample']=ncount_df['Sample'].astype(object)
 
     # Read BovPos csv and change ID to either 'Negative' or 'Mycobacterium bovis',
     # depending on number and relative abundance of M.bovis reads.
@@ -32,7 +32,7 @@ def combine(assigned_csv, bovis_csv, ncount_csv, seq_run, commitId, read_thresho
     # Fill empty value cells with zero 
     # TODO: Potential that not all scenarios are covered by the options below, so need to add default ID outcome
     bovis_df = pd.read_csv(bovis_csv)
-    bovis_df['Sample'].astype(object, inplace = True)
+    bovis_df['Sample']=bovis_df['Sample'].astype(object)
     qbovis_df = bovis_df.round(2)
     qbovis_df.loc[(qbovis_df['TotalReads'] >= read_threshold) & (qbovis_df['Abundance'] >= abundance_threshold), 'ID'] = 'Mycobacterium bovis'
     qbovis_df.loc[(qbovis_df['TotalReads'] < read_threshold) & (qbovis_df['Abundance'] < abundance_threshold), 'ID'] = 'Negative'

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -31,6 +31,7 @@ snps=$6
 bcf=$7
 MIN_ALLELE_FREQUENCY=$8
 pair_id=$9
+publishDir=$10
 
 
 # handle the case when the regions file is empty otherwise bcftools filter will fail
@@ -51,7 +52,7 @@ sed "/^>/ s/.*/>${pair_id}/" > $consensus
 # Count Ns in consensus file
 ncount=$(grep -o 'N' $consensus | wc -l)
 echo -e "Sample,Ncount,ResultLoc" > ${pair_id}_ncount.csv
-echo -e "${pair_id},$ncount,${params.outdir}/Results_${params.DataDir}_${params.today}" >> ${pair_id}_ncount.csv
+echo -e "${pair_id},$ncount,$publishDir" >> ${pair_id}_ncount.csv
 
 # Write SNPs table
 echo -e 'CHROM\tPOS\tTYPE\tREF\tALT\tEVIDENCE' > $snps

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -31,7 +31,7 @@ snps=$6
 bcf=$7
 MIN_ALLELE_FREQUENCY=$8
 pair_id=$9
-publishDir=$10
+publishDir=${10}
 
 
 # handle the case when the regions file is empty otherwise bcftools filter will fail

--- a/bin/vcf2Consensus.bash
+++ b/bin/vcf2Consensus.bash
@@ -50,8 +50,8 @@ sed "/^>/ s/.*/>${pair_id}/" > $consensus
 
 # Count Ns in consensus file
 ncount=$(grep -o 'N' $consensus | wc -l)
-echo -e "Sample,Ncount" > ${pair_id}_ncount.csv
-echo -e "${pair_id},$ncount" >> ${pair_id}_ncount.csv
+echo -e "Sample,Ncount,ResultLoc" > ${pair_id}_ncount.csv
+echo -e "${pair_id},$ncount,${params.outdir}/Results_${params.DataDir}_${params.today}" >> ${pair_id}_ncount.csv
 
 # Write SNPs table
 echo -e 'CHROM\tPOS\tTYPE\tREF\tALT\tEVIDENCE' > $snps

--- a/docker/install-all-dependancies.bash
+++ b/docker/install-all-dependancies.bash
@@ -27,7 +27,6 @@ sudo apt-get -y update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y
     libcurl4-openssl-dev \
     python3 \
     python3-pip \
-    vim \
     nano \
     bc
 
@@ -52,4 +51,3 @@ bash -e install-Kraken2.sh
 bash -e install-bracken.sh
 bash -e install-nextflow.sh
 bash -e install-sra-toolkit.sh
-bash -e install-dwgsim.sh

--- a/docker/install-dwgsim.sh
+++ b/docker/install-dwgsim.sh
@@ -1,6 +1,0 @@
-# dwgsim
-
-git clone --recursive https://github.com/nh13/DWGSIM.git
-cd DWGSIM/
-make
-sudo ln -s $PWD/dwgsim /usr/local/bin/dwgsim


### PR DESCRIPTION
The reprocess of the data included a step to collect the location of the results, but this information would have been missing from any new batches which will be added after the reprocess is complete.  Therefore the pipeline has been updated to include the `s3 uri` in the `ResultLoc` column of the `FinalOut` csv.  This should make the data capture from the reprocess simpler, and facilitate quick location of selected consensus files for snp matrices and tree building